### PR TITLE
Use `main` as documented.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "uid",
   "version": "0.0.2",
   "description": "generate unique ids of variable length",
-  "main": "yes",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/MatthewMueller/uid.git"


### PR DESCRIPTION
I was having an issue using a project that depends on uid inside of react-native– the packager couldn't resolve the uid module.  This fixed the issue.